### PR TITLE
Modify when conditional to use policy variable

### DIFF
--- a/tasks/section_1/cis_1.10.yml
+++ b/tasks/section_1/cis_1.10.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: "1.10 | PATCH | Ensure system-wide crypto policy is not legacy"
+- name: "1.10 | PATCH | Ensure system-wide crypto policy is set appropriately"
   shell: |
       update-crypto-policies --set "{{ rhel8cis_crypto_policy }}"
       update-crypto-policies
   notify: change_requires_reboot
   when:
       - rhel8cis_rule_1_10
-      - system_wide_crypto_policy['stdout'] == 'LEGACY'
+      - rhel8cis_crypto_policy|string not in system_wide_crypto_policy['stdout']
   tags:
       - level1-server
       - level1-workstation


### PR DESCRIPTION
**Overall Review of Changes:**
Check ignores the current setting of the rhel8cis_crypto_policy variable, assuming that the current policy is LEGACY (DEFAULT is the installation default). This effectively makes the rhel8cis_crypto_policy useless if the current policy is not LEGACY.

Since DEFAULT is the default setting on RockyLinux 8, the setting is never modified to FUTURE and results in a failed audit check.

**Issue Fixes:**
Modify the conditional to compare the value of rhel8cis_crypto_policy to the current value of system_wide_crypto_policy, if they don't match, apply the value from rhel8cis_crypto_policy.

**How has this been tested?:**
Modified the system-wide value to LEGACY and ran playbook, value was changed to FUTURE as expected.
Modified the system-wide value to DEFAULT and ran playbook, value was changed to FUTURE as expected.
